### PR TITLE
Remove scalable=no

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<meta name="author" content="Bludit CMS">
 
 	<!-- Dynamic title tag -->


### PR DESCRIPTION
Hi,
End users should be able to scale pages at all times so I would suggest to remove user-scalable=no from viewport meta tag.